### PR TITLE
Object bindings

### DIFF
--- a/src/utils/mapUtils.ts
+++ b/src/utils/mapUtils.ts
@@ -1,0 +1,9 @@
+// TODO is there some other types of intended use?
+export const mapObjectValueByIntendedUse = (value: any, intendedUse: string) => {
+  switch (intendedUse) {
+    case 'Percentage':
+      return `${(parseFloat(value) * 100)}%`
+    default:
+      return value;
+  }
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -121,7 +121,7 @@ const resolveObjectBindings = (entity: DynamicObject, sanitizedBinding: string, 
 
   // Reduce the keys of associated entity metadata, that are also keys of the value object. This way we get the intended use of the value object
   const valuePropertiesWithIntendedUse = Object.keys(associatedEntityMetadata as DynamicObject).reduce((acc, key) => {
-    console.log('key', key);
+    // console.log('key', key);
     if (Object.keys(value).includes(key)) {
       if (associatedEntityMetadata) {
         acc[key] = associatedEntityMetadata[key].IntendedUse;
@@ -135,7 +135,7 @@ const resolveObjectBindings = (entity: DynamicObject, sanitizedBinding: string, 
   // Iterate through the keys of the value and replace the value with the intended use
   for (const [key, val] of Object.entries(valueObjectToParse)) {
     if (Object.keys(valuePropertiesWithIntendedUse).includes(key)) {
-      console.log('val', val);
+      // console.log('val', val);
       valueObjectToParse[key] = mapObjectValueByIntendedUse(val, valuePropertiesWithIntendedUse[key]);
     }
   }


### PR DESCRIPTION
## Muutokset ja syyt muutoksille?

Object -tyyppisten arvojen bindingien parsiminen

## Muutoksien testaus

Testattu käymällä läpi rekisterinäkymät, joissa oli vielä parsimattomia objekteja. Nyt niissä kentissä näkyy oikeamuotoinen teksti.

## Kuvakaappaus

![image](https://user-images.githubusercontent.com/71371635/224347905-ba444f8a-1ba4-4a7b-8d18-ccef20f57909.png)
Kuvan ALV-kanta -sarakkeen arvot ovat objektityyppiä ja näkyvät nyt oikein.
