### PR TITLE
Implement zustand store for views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "jest-junit": "^15.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.8.1"
+        "react-router-dom": "^6.8.1",
+        "zustand": "^4.3.6"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.20.2",
@@ -9793,6 +9794,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.6.tgz",
+      "integrity": "sha512-6J5zDxjxLE+yukC2XZWf/IyWVKnXT9b9HUv09VJ/bwGCpKNcaTqp7Ws28Xr8jnbvnZcdRaidztAPsXFBIqufiw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "jest-junit": "^15.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.8.1"
+    "react-router-dom": "^6.8.1",
+    "zustand": "^4.3.6"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,15 @@ import { Sidebar } from './components/Sidebar';
 import { MainView } from './components/MainView';
 import { ApplicationBar } from './components/ApplicationBar';
 import { Outlet, useNavigation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { getSchemaToStore } from './utils/storeUtils';
 
 function App() {
     const navigation = useNavigation();
+
+    useEffect(() => {
+        getSchemaToStore();
+    }, []);
 
     return (
         <div className="App w-full flex">

--- a/src/components/View/ShowView.tsx
+++ b/src/components/View/ShowView.tsx
@@ -3,12 +3,12 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { ViewHeader } from './ViewHeader';
 import { useIsFetching, useQuery } from '@tanstack/react-query';
 import { getViewFromSchemaByName } from '../../utils/Parser';
-import { schemaQuery } from '../../temp/SchemaUtils';
 import { CardView } from './CardView';
 import { useEffect } from 'react';
+import useSchemaStore from '../../store/store';
 
 export const ShowView = () => {
-    const { data: schema } = useQuery(schemaQuery());
+    const schema = useSchemaStore((state: any) => state.schema);
     const { viewId } = useParams();
     const { Id } = useParams();
     const navigate = useNavigate();
@@ -19,14 +19,13 @@ export const ShowView = () => {
         error,
     } = useQuery({
         queryKey: ['schema', 'metaview', viewId],
-        queryFn: () => getViewFromSchemaByName(schema!, viewId!),
-        enabled: !!schema,
+        queryFn: () => getViewFromSchemaByName(schema, viewId!),
+        enabled: Object.keys(schema).length > 0,
     });
     const isLoadingSchema = useIsFetching(['schema', 'metaview', viewId]) > 0;
 
     useEffect(() => {
         if (isError) {
-            console.log(error);
             navigate('/somewhere');
         }
     }, [isError, error]);

--- a/src/components/View/ViewList.tsx
+++ b/src/components/View/ViewList.tsx
@@ -1,25 +1,23 @@
 import React, { ChangeEventHandler } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { sortByDocumentHeader } from '../../utils/sortingUtils';
-import { useIsFetching, useQuery } from '@tanstack/react-query';
-import { schemaQuery } from '../../temp/SchemaUtils';
 import { getRegisterViewsFromSchema } from '../../utils/Parser';
+import useSchemaStore from '../../store/store';
+import { useEffect, useState } from 'react';
 
 export const ViewList = ({ className }: { className?: string }) => {
     const navigate = useNavigate();
-    const { data: schema } = useQuery(schemaQuery());
-    const { data: registerViews } = useQuery({
-        queryKey: ['schema', 'metaview', 'register', 'all'],
-        queryFn: () => getRegisterViewsFromSchema(schema),
-        enabled: !!schema,
-    });
-    const isLoading =
-        useIsFetching(['schema', 'metaview', 'register', 'all']) > 0;
+    const [registerViews, setRegisterViews] = useState<Document[]>([]);
+    const schemaInStore = useSchemaStore((state: any) => state.schema);
 
     const handleOnChange: ChangeEventHandler<HTMLSelectElement> = (evt) => {
         evt.preventDefault();
         navigate(`view/${evt.target.value}`);
     };
+
+    useEffect(() => {
+        setRegisterViews(getRegisterViewsFromSchema(schemaInStore));
+    }, [schemaInStore]);
 
     const registerViewNames = registerViews
         ?.sort(sortByDocumentHeader)
@@ -37,14 +35,15 @@ export const ViewList = ({ className }: { className?: string }) => {
 
     return (
         <div className={`px-8 py-4`}>
-            {isLoading && <p>Loading view names...</p>}
-            {registerViewNames?.length && (
+            {registerViewNames?.length !== 0 ? (
                 <select
                     className={`border-2 border-slate-200 hover:border-blue-400 cursor-pointer rounded p-2 ${className}`}
                     onChange={handleOnChange}
                 >
                     {registerViewNames}
                 </select>
+            ) : (
+                <p>Loading view names...</p>
             )}
         </div>
     );

--- a/src/services/backend.ts
+++ b/src/services/backend.ts
@@ -31,6 +31,7 @@ type EntitySearchTypes = {
   Also, return type is any for
 */
 export async function getSchema() {
+    console.log('----------------- Getting schema -----------------');
     const loginData: LoginData = {
         Username: import.meta.env.VITE_ASSISCARE_USER,
         Password: import.meta.env.VITE_ASSISCARE_PASS,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface SchemaStore {
+    schema:
+        | {
+              string: [];
+          }
+        | {};
+}
+
+const useSchemaStore = create<SchemaStore>()(() => ({
+    schema: {},
+}));
+
+export default useSchemaStore;

--- a/src/utils/storeUtils.ts
+++ b/src/utils/storeUtils.ts
@@ -1,0 +1,10 @@
+import { getSchema } from '../services/backend';
+import useSchemaStore from '../store/store';
+
+export const getSchemaToStore = () => {
+    getSchema().then((res) => {
+        useSchemaStore.setState({ schema: res });
+        const data = useSchemaStore.getState()?.schema;
+        console.log("Schema in store :>>", data);
+    });
+};


### PR DESCRIPTION
## Muutokset ja syyt muutoksille?

Ottaa zustand-storen käyttöön view-komponenteissa. Käyttää rinnalla react-querya, kun schemaa parsitaan näkymissä. Toteutuksesta puuttuu vielä schema.jsonin korvaaminen storella.

## Muutoksien testaus

Testattu käsin kokeilemalla eri näkymiä ja routeja. Testit menee läpi, koska ne käyttää vielä schema.json (tulevaisuudessa on varmaan järkevää käyttää sitä testiympäristössä, jottei testit ole riippuvaisia apista...)

~~WIP, koska schema.json on vielä käytössä. Toki tämän voisi mergeä näinkin jsonin rinnalle.~~
Tää PR on hyvällä mallilla ja asiat toimii rinnakkain jsonin kanssa. https://github.com/mnir29/assisdent-web-client/pull/40 on muutoksia, jotka kannattaa mergeä toisena palasena myöhemmin.