### PR TITLE
Add new button rendering now corresponds more to schema

### DIFF
--- a/src/components/View/RegisterView.tsx
+++ b/src/components/View/RegisterView.tsx
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { getEntitiesForRegisterView } from '../../services/backend';
 import { RegisterTable } from './RegisterTable';
 import { DynamicObject } from '../../types/DynamicObject';
-import { parseRegisterMetaView, parseOrderOptions } from '../../utils/Parser';
+import { parseOrderOptions, parseRegisterMetaView } from '../../utils/Parser';
 import { getUserLanguage } from '../../utils/utils';
 import { DEFAULT_SHOW_ON_PAGE, ShowOnPageOption } from '../../utils/constants';
 import { Toolbar } from './Toolbar';

--- a/src/components/View/ShowView.tsx
+++ b/src/components/View/ShowView.tsx
@@ -9,6 +9,8 @@ import useSchemaStore from '../../store/store';
 import { SchemaStore } from '../../types/SchemaStore';
 import Button from '../Button';
 import { ApplicationBar } from '../ApplicationBar';
+import { getRegisterMetaViewAsObject } from '../../utils/objectUtils';
+import { DynamicObject } from '../../types/DynamicObject';
 
 export const ShowView = () => {
     const schema = useSchemaStore((state: SchemaStore) => state.schema);
@@ -34,7 +36,17 @@ export const ShowView = () => {
     }, [isError, error]);
 
     const Header = entity?.documentElement.getAttribute('Header');
-    const EntityType = entity?.documentElement.getAttribute('EntityType');
+
+    let MetaViewObject: DynamicObject = {};
+    let NewCardName: string | null = null;
+    let createNewCardDisabled = false;
+
+    if (entity) {
+        MetaViewObject = getRegisterMetaViewAsObject(entity.documentElement);
+        NewCardName = MetaViewObject.CreateNewCardName;
+        createNewCardDisabled =
+            MetaViewObject.DisableCreateNewEntity === 'true';
+    }
 
     return (
         <>
@@ -55,13 +67,19 @@ export const ShowView = () => {
                             </>
                         )}
                     </section>
-                    <ApplicationBar>
-                        <Link to={`/view/${EntityType}CardView/new`}>
-                            <Button onClick={() => null} buttonType={'primary'}>
-                                Lisää uusi
-                            </Button>
-                        </Link>
-                    </ApplicationBar>
+                    {NewCardName && (
+                        <ApplicationBar>
+                            <Link to={`/view/${NewCardName}/new`}>
+                                <Button
+                                    onClick={() => null}
+                                    buttonType={'primary'}
+                                    disabled={createNewCardDisabled}
+                                >
+                                    Lisää uusi
+                                </Button>
+                            </Link>
+                        </ApplicationBar>
+                    )}
                 </>
             ) : (
                 <>

--- a/src/utils/objectUtils.ts
+++ b/src/utils/objectUtils.ts
@@ -45,3 +45,22 @@ export const checkIfObjectHasNestedProperty = (
     }
     return true;
 };
+
+const getElementsFromViewAsObjectRecursive = (root: Element) => {
+    const resultObj: DynamicObject = { TagName: root.tagName };
+    for (const attrName of root.getAttributeNames()) {
+        resultObj[attrName] = root.getAttribute(attrName);
+    }
+    if (root.hasChildNodes()) {
+        resultObj['Children'] = [] as DynamicObject[];
+        for (let i = 0; i < root.children.length; i++) {
+            resultObj['Children'].push(
+                getElementsFromViewAsObjectRecursive(root.children[i]),
+            );
+        }
+    }
+    return resultObj;
+};
+export const getRegisterMetaViewAsObject = (view: Element) => {
+    return getElementsFromViewAsObjectRecursive(view);
+};


### PR DESCRIPTION
## Muutokset ja syyt muutoksille?

Uuden entiteetin luomispainikkeen renderöinti nyt enemmän skeeman mukainen

## Muutoksien testaus

npm run dev. Esimerkiksi "Hyvityksen kohdistukset" -rekisterinäkymässä näkyy nyt "Luo uusi" disabloituna, kun taas esimerkiksi Potilaat -näkymässä se on normaalisti toiminnassa.

## Kuvakaappaus

N/A
